### PR TITLE
Season fix

### DIFF
--- a/config/sereneseasons/seasons.cfg
+++ b/config/sereneseasons/seasons.cfg
@@ -1,0 +1,46 @@
+# Configuration file
+
+"aesthetic settings" {
+    # Change the birch colour based on the current season [default: true]
+    B:"Change Birch Colour Seasonally"=true
+
+    # Change the foliage colour based on the current season [default: true]
+    B:"Change Foliage Colour Seasonally"=true
+
+    # Change the grass colour based on the current season [default: true]
+    B:"Change Grass Colour Seasonally"=true
+}
+
+
+"dimension settings" {
+    # Seasons will only apply to dimensons listed here [default: [0]]
+    S:"Whitelisted Dimensions" <
+        0
+     >
+}
+
+
+"time settings" {
+    # The duration of a Minecraft day in ticks [range: 20 ~ 2147483647, default: 24000]
+    I:"Day Duration"=72000
+
+    # If the season should progress on a server with no players online [default: true]
+    B:"Progress Season While Offline"=true
+
+    # The starting sub season for new worlds.  0 = Random, 1 - 3 = Early/Mid/Late Spring, 4 - 6 = Early/Mid/Late Summer, 7 - 9 = Early/Mid/Late Autumn, 10 - 12 = Early/Mid/Late Winter [range: 0 ~ 12, default: 5]
+    I:"Starting Sub Season"=5
+
+    # The duration of a sub season in days [range: 1 ~ 2147483647, default: 7]
+    I:"Sub Season Duration"=7
+}
+
+
+"weather settings" {
+    # Change the frequency of rain/snow/storms based on the season [default: true]
+    B:"Change Weather Frequency"=true
+
+    # Generate snow and ice during the Winter season [default: true]
+    B:"Generate Snow and Ice"=true
+}
+
+

--- a/index.toml
+++ b/index.toml
@@ -493,6 +493,10 @@ file = "config/sereneseasons/cropfertility.cfg"
 hash = "8aaf6bfca1e35261e22053daa1f18b73f0997dd8eeb519baff96d2815ba70f58"
 
 [[files]]
+file = "config/sereneseasons/seasons.cfg"
+hash = "158e0e394903f4048e73f6ce99a7d777f2e82da6610a73e179c8f6cc0a3eb876"
+
+[[files]]
 file = "config/setbonus/1.12.2.009+.cfg"
 hash = "81c573a26fd80be6673b5a0c1fa4e6745cc4b722b322b096936f19171f3da7bf"
 

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "c6866a714f50a9f60369f004a1f5112d1570743d6a7e9f588f4d8c46a0c84f59"
+hash = "6ea6db2e9944b1e2168c29e420001a54677b4e5d21f184736ee0781cd57f86d1"
 
 [versions]
 forge = "0.3.13-alpha"


### PR DESCRIPTION
- Resolved an oversight that cause seasons to still operate on vanilla's 24000 tick (20 minute) daylight cycle instead of Project Virulence's 72000 tick (60 minute) daylight cycle